### PR TITLE
Add Actuator Dependency and Configure Kubernetes Probes

### DIFF
--- a/manifests/project-registry-backend-deployment.yml
+++ b/manifests/project-registry-backend-deployment.yml
@@ -21,12 +21,22 @@ spec:
         - containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /api/project
+            path: /api/project/actuator/health/liveness
             port: 8080
+            failureThreshold: 6 # 6 checks -> 1 minute of allowed downtime before restarting
+            periodSeconds: 10
         startupProbe:
           httpGet:
-            path: /api/project
+            path: /api/project/actuator/health/readiness
             port: 8080
+            failureThreshold: 18 # 18 checks -> 3 minutes for worst-case ready time
+            periodSeconds: 10 # 10 seconds between checks
+        readinessProbe:
+          httpGet:
+            path: /api/project/actuator/health/readiness
+            port: 8080
+            failureThreshold: 6 # 6 checks -> 1 minute of allowed downtime before restarting
+            periodSeconds: 10
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
 	</properties>
 
 	<dependencies>
+	
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.datasource.url=jdbc:h2:mem:testdb
 spring.jpa.hibernate.ddl-auto=update
 
 logging.level.com.revature=DEBUG
+
+management.endpoint.health.enabled=true


### PR DESCRIPTION
Spring Boot Actuator provides `/readiness` and `/liveness` endpoints when run in a Kubernetes context. This provides a very convenient set of endpoints to use for Kubernetes Probes.

They were previously configured in a simple manner, but this new configuration will be more effective at identifying the current status of this application inside Kubernetes.

Additionally, more Actuator endpoints can be exposed in the future as needed.